### PR TITLE
footer-menusのレイアウト崩れの修正

### DIFF
--- a/app/views/calendars/edit.html.erb
+++ b/app/views/calendars/edit.html.erb
@@ -16,4 +16,3 @@
     <%= form.submit "送信", class: "btn btn-block px-5 font font-size mt-3 calendar-button py-3" %>
   <% end %>
 </div>
-<%= render 'layouts/footer-menus' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,10 @@
       <div class="container-fluid <%= devise_controller? ? 'mw-md' : 'mw-xl' %>">
         <%= yield %>
       </div>
+      <% if controller_name == 'homes' %>
+      <% else %>
+        <%= render 'layouts/footer-menus' %>
+      <% end %>
       <%= render 'layouts/footer' %>
     </div>
   </body>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -5,4 +5,3 @@
 </div>
 <h3 class="text-center font font-size">【変更日の日付】 <%=l @note.date, format: :long %></h3>
 <%= render "form" %>
-<%= render 'layouts/footer-menus' %>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -29,4 +29,3 @@
     <% end %>
   </div>
 <% end %>
-<%= render 'layouts/footer-menus' %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,4 +1,3 @@
 <h1 class="text-center font">連絡帳の記入</h1>
 <h3 class="text-center font font-size">【今日の日付】 <%= l Date.current, format: :long %></h3>
 <%= render "form" %>
-<%= render 'layouts/footer-menus' %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -13,4 +13,3 @@
 <div class="mb-3 font text-center"><%= @note.temp %>度</div>
 <div class="stitch-index bgc-grey font text-center mb-2">メッセージ</div>
 <div class="mb-3 font text-left format-width mx-auto bgc-grey"><%= @note.message %></div>
-<%= render 'layouts/footer-menus' %>

--- a/app/views/receptions/edit.html.erb
+++ b/app/views/receptions/edit.html.erb
@@ -5,4 +5,3 @@
 <div id="card-reception">
   <%= render "reception_card"%>
 </div>
-<%= render 'layouts/footer-menus' %>

--- a/app/views/receptions/show.html.erb
+++ b/app/views/receptions/show.html.erb
@@ -23,6 +23,7 @@
   <% else %>
     <%=l @reception.arrive, format: :long %></div>
 <% end %>
+</div>
 <div class="stitch-index bgc-blue font text-center mb-2">退所時間</div>
 <div class="mb-3 font text-center">
   <% if @reception.nil? %>
@@ -32,4 +33,3 @@
   <% else %>
   <% end %>
 </div>
-<%= render 'layouts/footer-menus' %>


### PR DESCRIPTION
## 概要
- footer-menusのレイアウト崩れの修正
### 内容
- reception.showファイル内のhtmlのdivの閉じタグが足りなかったため、修正